### PR TITLE
Expansion of Part 1: Introduction

### DIFF
--- a/.pansite.yaml
+++ b/.pansite.yaml
@@ -15,6 +15,8 @@ routes:
   target: $(@D)/part06.html
 - path: q-and-a
   target: $(@D)/q-and-a.html
+- path: addenda
+  target: $(@D)/addenda.html
 - path: css/buttondown.css
   target: resources/buttondown.css
 - path: js/main.js

--- a/addenda.md
+++ b/addenda.md
@@ -1,0 +1,38 @@
+---
+  title: "Addenda"
+---
+
+# Naming conventions
+
+* Values and type variables start with initial lower-case letter
+* Types and type classes start with initial capital letter
+* Names typically employ medial capitalization, e.g. `MyType` and `myFunction` instead of `My_Type` and `my_function`, though this is not enforced
+* Punctuation such as `'` allowed
+* Some common, but not mandatory, suffixes exist including `M` and `M_` etc., e.g. `foldM`, `mapM` and `forM_`
+* Operators are no different from functions except their names are spelt with symbol characters and can be used infix
+* Backticks can be used to use regular functions infix while parentheses can be employed to use operators in function-style prefix position
+* Type and data constructors are separate namespaces and can, therefore, share names
+* It is not uncommon to see type constructors with identically named data constructors, which we'll see later
+
+# Pronunciation
+
+| Symbol | Pronunciation |
+|--------|:-------------:|
+| `=>`   | implies       |
+| `->`   | to, maps to   |
+
+
+# Further Discussion
+
+## Mathematical Functions
+
+Mathematical functions define relationships between input and output.  Accordingly, all mathematical functions can be represented as a table of pairs of values.  For example `f(x) = x + 1` can be represented:
+
+|x|f(x)|
+|---|---|
+|0|1|
+|1|2|
+|2|3|
+
+
+

--- a/part01.md
+++ b/part01.md
@@ -2,94 +2,150 @@
 title: "Part 1: Introduction"
 ---
 
+In this introduction, we'll get acqainted with Haskell in three indispensable ways. First, through a _very brief_ overview of its features to orient us in our study. Then we'll jump into a Haskell REPL to see some simple Haskell expressions, but also to practice using the REPL as a development tool. Finally, we'll work with a source file, and create a minimalist project with Stack.
+
 # What is Haskell?
 
 *[Sources: [1][haskellwikifp], [2][wikipediahaskell], [3][evaluation]]*
 
-* Purely functional programming language
-* Non-strict
-* Statically typed
-* Call-by-need
-* Whitespace-sensitive syntax
-* Memory managed using garbage collector
-* Naming conventions
+## Purely functional
 
-## Purely functional programming language
+Functions are first-class citizens that can be passed as arguments to other functions, "returned" from other functions, and stored in data structures, e.g. lists. (The notion of returning a value belongs to imperative languages, the appropriate term is _evaluates to_.)
 
-* Functional
-	* Functions are first-class objects
-	* Effectively values that can be passed around
-* Pure
-    * Haskell functions more closely resemble mathematical functions
-    * Given any input value, they return the same output
-    * This is _referential transparency_
-    * Typically operate on immutable data
-    * No side effects
-    * Referential transparency means that the compiler is free to do all kinds of optimization such as interleaving and inlining etc. which typically require additional annotations or data flow analysis in compilers for languages such as C++ and Java
+In Haskell, functions closely resemble [mathematical functions][mathematicalfunctions]: given any input value, they always return the same output; this is called [referential transparency][referentialtransparency]. Functions typically operate on _immutable_ data, and do not have side effects.
 
-## Non-strictness
+Referential transparency means that the compiler is free to do all kinds of optimization such as interleaving and [inlining][inlining] etc. which typically require additional annotations or data flow analysis in compilers for languages such as C++ and Java.
 
-* Function arguments not evaluated unless they're actually used
-* A strict function is one which always evaluates all of its arguments
-* Non-strictness allows lazy evaluation
-* Haskell has annotations for strict evaluation where necessary
-* Lazy evaluation allows control structures to be built from user-defined functions
+## Non-strict
 
-## Static typing
+Function arguments not evaluated unless they're actually used (a strict function is one which always evaluates all of its arguments). Non-strictness allows for _lazy evaluation_ (note the [difference][nonstrictversuslazy] between non-strictness and lazy evaluation).  Haskell employs lazy evaluation by default, but has annotations for strict evaluation where necessary. Lazy evaluation allows control structures to be built from user-defined functions.
 
-* Catch many kinds of programmer error at _compile time_
-* Expressive type system allows programmer lots of power and flexibility
+## Statically typed
+
+Haskell is a staticaly typed language, which allows the compiler to catch many kinds of programmer error at _compile time_.  But Haskell's type system is highly expressive, and allows programmer lots of power and flexibility.  The expressivity of the type system itself -- the same machanism which provides safety and certain guarantees about the program -- is one of the features which sets Haskell apart from other languages.
 
 ![Simon Peyton Jones's "Region of Abysmal Pain" Venn diagram][spjvenn]
 
 ## Call-by-need
 
-* Effectively call-by-name with memoization
-* _If a function is evaluated_ its value is stored for future uses
+Haskell uses a call-by-need evaluation strategy, which is effectively [call-by-name][callbyname] with memoization.  Call-by-name is an evaluation strategy where a function's arguments aren't evaluated prior to the function's call, but are substituted into the body of the function itself. With call-by-need, _if a function argument is evaluated_ its value is stored for future uses.
 
-## Whitespace-sensitive syntax
+## Minimalist syntax
 
-* Like Python, Haskell is an [off-side rule language][offsiderule]
-* Most of the time the required indentation is what feels right
+Haskell's syntax largely follows from the privileged role of functions, thus functions assume the simplest and least-decorated place in Haskell's syntax.  A mathematical function such as `f(x) = x` is rendered `f x = x` in Haskell; no elipses wrapping arguments, and no braces closing the function body.
 
-## Garbage collection
+In addition, Haskell uses an [off-side rule language][offsiderule] syntax, much like Python; most of the time the required indentation is what feels right.
 
-* Haskell computations can produce a lot of memory garbage
-* Partly a consequence of non-strict evaluation which involves accumulation of _thunks_ in memory
-* Also, partly a result of immutability
-* However, the GHC runtime's GC is highly tuned for this behaviour
-* Manual management of external resources such as externally allocated memory or resource handles is possible
+## Garbage collected
 
-## Naming conventions
-
-* Values and type variables start with initial lower-case letter
-* Types and type classes start with initial capital letter
-* Names typically employ medial capitalization, e.g. `MyType` and `myFunction` instead of `My_Type` and `my_function`, though this is not enforced
-* Punctuation such as `'` allowed
-* Some common, but not mandatory, suffixes exist including `M` and `M_` etc., e.g. `foldM`, `mapM` and `forM_`
-* Operators are no different from functions except their names are spelt with symbol characters and can be used infix
-* Backticks can be used to use regular functions infix while parentheses can be employed to use operators in function-style prefix position
-* Type and data constructors are separate namespaces and can, therefore, share names
-* It is not uncommon to see type constructors with identically named data constructors, which we'll see later
-
-## What else?
-
-* Haskell has a clean, minimal syntax
-* Much of this is a consequence of some of these other characteristics
-* Example: non-strict evaluation allows us to _build_ certain flow control constructs where other languages require language-level syntax
-* To a first approximation, Haskell programs consist of two elements:
-    * Definitions
-    * Expressions
-* Nontrivial Haskell programs will also likely include some extras:
-    * Type annotations
-    * Pragmas
-    * Import statements
+Haskell employs its own garbage collection to manage memory. Haskell computations can produce a lot of memory garbage, partly as a consequence of non-strict evaluation which involves accumulation of _thunks_ in memory, and partly a result of immutability. However, the GHC runtime's GC is highly tuned for this behaviour.   Haskell does afford manual management of external resources such as externally allocated memory or resource handles.
 
 # Our first Haskell code
 
-## Interactive Haskell
+Let's open a Haskell REPL and a project with a source file to work with.
 
-First you'll need to start your terminal or command prompt. Once you've done that, we'll create a brand-new Stack project named `hello-world`:
+## GHCi
+
+Next  we'll start up GHCi, the interactive Haskell interpreter.
+
+Run `stack ghci` and you'll see a prompt `Prelude>`.  GHC stands for the Glasgow Haskell Compiler, GHCi is GHC _Interactive_, GHC's read-evaluate-print-loop (REPL).
+
+You can configure the GHCi prompt by entering `:set prompt "ghci> "` into GHCi. You can also enter this line into a `.ghci` dotfile in your home directory. Here we've configured the prompt to display `λ>` for pertinence and brevity.
+
+For our first steps using Haskell, let's assign some values and evaluate some _expressions_.
+
+```bash
+λ> x = 5
+```
+
+This assigns name `x` to value `5`.
+
+Note that we say "assigns name `foo` to `bar`" as opposed to "assigns value `bar` to `foo`. In imperative programming languages `=` or equivalent operators typically perform _assignment_ and the different values can be assigned to existing names from time to time. In Haskell, the name `foo` is _defined to be_ the `value` in the equational sense of `=`: it's a definition and this is at the root of [equational reasoning][equationalreasoning].
+
+```bash
+λ> x = 5
+λ> y = 6
+λ> z = x + y
+```
+Now we've assigend the name `z` to the expression  `x + y`, but we still haven't seen any evaluation.
+
+```bash
+λ> z
+11
+```
+Here the expression `z` is evaluated.
+
+We can use GHCi to do more than assignments and evaluations. We can also retrieve information about values and expressions:
+
+```bash
+λ> :type z
+z :: Num a => a
+```
+
+We just asked GHC to tell us the `type` of the expression `z` and it printed out the type signature for `z`.  `Num a` is the type class `Num` with one type variable `a`. More on this later. Note, however, that we did not specify a type for `z`, the compiler inferred it. In the absence of type annotations&mdash;which we'll cover later&mdash;GHCi will typically assign the most general type possible to an expression, subject to certain rules.
+
+GHCi will assign exactly one type to a given expression. Despite the absence of explicit type annotations in this example, the expressions are still strongly and statically typed.
+
+A type signature consists of:
+
+* One or more constraints to the left of `=>` (such constraints are optional)
+* One or more types separated by `->`
+
+<span class="marginnote">Types and [_type classes_][typeclasses] always spelt with initial upper-case letter. Type variables always spelt with initial lower-case letter.</span>
+
+Let's look at another type:
+
+```bash
+λ> z = "hello"
+λ> z
+hello
+λ> :t z
+z :: [Char]
+```
+
+Here we've assigned `z` to "hello", evaluated it, and used the shorthand `:t` for `:type` to show its type signature.  The type `[Char]` is a list of `Char`. 
+
+```bash
+λ> :t (+)
+(+) :: Num a => a -> a -> a
+```
+
+Here are other GHCi commands:
+
+| Command | Alias | Use    | 
+|---------|---------|-------|
+| `:type` | `:t`  | type signature of the given value or  expression |
+| `:info` | `:i` | information about the given name |
+| `:kind` | `:k` | information about the kind of the given type |
+| `:quit` | `:q` | quit ghci |
+
+GHCi has many other commands, which you can peruse [here][ghcicommands].
+
+### Exercises 
+
+#### Use GHCi with to explore different values and expressions
+
+Familiarize yourself with GHCi by investigating the following expressions in GHCi with `:type` and `:info` and `:kind`
+
+1. `4`, `8 / 4`, and `4.0`
+2. `x = 42 + 3 ^ 2`
+3. `(+)` and `(-)`
+4. `(*)` and `(/)`
+5. `(^)`
+6. `True` and `False`
+7. `&&` and `||`
+8. `f a = a + 1`
+9. `g a b = a + b`
+10. `Num`
+11. `Integer`
+
+## Create a project with Stack
+
+Now that we have some familiarity with the REPL, let's look at how to work with a source file.
+
+As mentioned earlier, the examples in this course use Stack to run Haskell.  Here are [setup instructions][stacksetup].
+
+Stack provides templates for bootstrapping projects. In a terminal or command prompt create a brand-new Stack project named `hello-world`:
 
 ```bash
 stack new hello-world simple --resolver=lts-7.8
@@ -104,47 +160,7 @@ The `simple` template is one of the simplest-possible Haskell projects: a projec
 * `src/Main.hs`: a simple starter source file
 * `stack.yaml`: a Stack-specific configuration file
 
-Next we'll start up GHCi, the interactive Haskell interpreter:
-
-```bash
-stack ghci
-```
-
-* GHC is the Glasgow Haskell Compiler
-* GHCi is GHC _Interactive_
-* It's GHC's read-evaluate-print-loop (REPL)
-* I've configured my prompt to display `λ>` but the default is likely to be `Prelude>` or `Main>`
-* Let's assign some values and evaluate some _expressions_
-
-Input                           | Output            | Comment
-:-------------------------------|:------------------|:-------
-`λ> x = 5`                      |                   | Assigns name `x` to value `5`
-`λ> y = 6`                      |                   | Assigns name `y` to value `6`
-`λ> z = x + y`                  |                   | Assigns name `z` to value `x + y`
-`λ> z`                          | `11`              | Evaluates `z` and displays value
-`λ> :type z`<br>or<br>`λ> :t z` | `z :: Num a => a` | Shows type of `z`
-`λ> :t 5`                       | `5 :: Num t => t` | Shows type of `5`
-`λ> z = "hello"`                |                   | Assigns name `z` to value `"hello"`
-`λ> z`                          | `"hello"`         | Evaluates `z` and displays value
-`λ> :t z`                       | `z :: [Char]`     | Shows type of `z`
-`λ> :t (+)`											| `(+) :: Num a => a -> a -> a` | Shows type of `+` operator
-`λ> :q`                         |                   | Quits GHCi session
-
-Notes:
-
-* We say "assigns name `foo` to `bar`" as opposed to "assigns value `bar` to `foo`"
-    * In imperative programming languages `=` or equivalent operators typically perform _assignment_ and the different values can be assigned to existing names from time to time
-    * In Haskell, the name `foo` is _defined to be_ the `value` in the equational sense of `=`: it's a definition and this is at the root of [equational reasoning][equationalreasoning]
-* In the absence of type annotations&mdash;which we'll cover later&mdash;GHCi will typically assign the most general type possible to an expression, subject to certain rules
-* GHCi will assign exactly one type to a given expression
-* Despite the absence of explicit type annotations in this example, the expressions are still strongly and statically typed
-* Type signatures consist of:
-    * Optional: one or more constraints to the left of `=>` ([pronounced][pronunciation] "implies")
-    * Types and [_type classes_][typeclasses] always spelt with initial upper-case letter
-    * Type variables always spelt with initial lower-case letter
-    * One or more types separated by `->` (pronounced "to")
-    * We haven't seen any `->` yet, but we will soon
-* `Num a` is the type class `Num` with one type variable `a`: more on this later
+Because this project has only one source file, you can run that source file directly with `stack runhaskell src/Main.hs`, and get "hello world" triumphantly printed to the terminal. A more standard procedure for a project would be to `stack install` to resolve dependencies, then `stack build` to compile, and finally `stack exec hello-world`.
 
 ## Your first Haskell source file
 
@@ -158,9 +174,7 @@ z = x + y
 main = print z
 ```
 
-* Most things you type into GHCi are valid lines of code in a Haskell source file
-* In order to be able to run a program, a Haskell program must have exactly one function named `main` in the `Main` module (or unnamed module) and must have an `IO` type
-* `print` is a function that takes as an argument any value that has an instance of the `Show` type class: we'll talk about type classes more later
+Most things you type into GHCi are valid lines of code in a Haskell source file.  In order to be able to run a program, a Haskell program must have exactly one function named `main` in the `Main` module (or unnamed module) and must have an `IO` type. `print` is a function that takes as an argument any value that has an instance of the `Show` type class: we'll talk about type classes more later.
 
 Now we can run the program as follows:
 
@@ -196,15 +210,16 @@ There are naturally many differences between the interactive and non-interactive
 
 * Names can be _shadowed_ in GHCi: i.e. we can introduce a new `z` that _hides_ the previous definition with name `z`
 * In Haskell source files, a top-level name can be used exactly once
-* Shadowing is allowed within Haskell source files, specifically within nested lexical scopes
+* [Shadowing][shadowing] is allowed within Haskell source files, specifically within nested lexical scopes
 * In fact, that is exactly what's happening in GHCi: each line entered at the prompt is effectively a new lexical scope nested within the previous lexical scope
 
 # A more realistic example
 
 *[Sources: [1][haskellnumbers]]*
 
-* Let's add some type annotations
-* Start up GHCi again
+So far we've only seen type signatures when querying GHCi, but we can provide type annotations to expressions to explicitly declare types.  Let's do this in GHCi and then in a source file.
+
+Start up GHCi again:
 
 ```ghci
 λ> x :: Integer; x = 5
@@ -223,7 +238,7 @@ z :: Integer
 a :: Num t => t
 ```
 
-* Let's do that in our source file:
+Now do the same in our source file:
 
 ```haskell
 x :: Integer
@@ -239,23 +254,22 @@ main :: IO ()
 main = print z
 ```
 
-* Consider the type of `a`:
-    * Lower-case `t` is a _type variable_ and can be any type that fulfils the type constraints
-    * `Num t` constrains `t` to be an instance of the `Num` type class
-    * `Num` has instances for (or "is implemented by") all primitive numeric types in Haskell
-* Consider the type of `x`, `y` and `z`:
-    * These have no `=>` and, therefore, no type constraints
-    * Upper-case `Integer` is a _concrete type_ corresponding to arbitrary-precision integers: this is an _instance_ of `Num`
-* We'll talk about `IO ()` next lesson
+Consider the contrasting result, in our GHCi example, for type of `a` as `a :: Num t = t`:
+
+* Lower-case `t` is a _type variable_ and can be any type that fulfils the type constraints
+* `Num t` _constrains_ `t` to be some type which is an instance of the `Num` type class
+* `Num` has instances for (or "is implemented by") all primitive numeric types in Haskell
+
+Consider the type of `x`, `y` and `z`:
+
+* These have no `=>` and, therefore, no type constraints
+* Upper-case `Integer` is a _concrete type_ corresponding to arbitrary-precision integers: this is an _instance_ of `Num`
+
+We'll talk about the `IO ()` type in the next lesson.
 
 ## When to use type annotations
 
-* Haskell has powerful type inference
-* Haskell designed in such a way that usually you won't need them
-* Sometimes ambiguities arise
-* Some more [advanced language features][dependenttypes] make ambiguities more likely
-* Even so, type annotations are useful as documentation and for type-driven development
-* Most experienced Haskell developers recommend that all _top-level_ definitions should carry a type annotation
+Haskell has powerful type inference, designed so that usually you won't need them.  But sometimes ambiguities arise, and some more [advanced language features][dependenttypes] make ambiguities more likely.  Even so, type annotations are useful as documentation and for type-driven development, and most experienced Haskell developers recommend that all _top-level_ definitions should carry a type annotation.
 
 [dependenttypes]: https://wiki.haskell.org/Dependent_type
 [equationalreasoning]: http://www.haskellforall.com/2013/12/equational-reasoning.html
@@ -267,3 +281,11 @@ main = print z
 [spjvenn]: images/region-of-abysmal-pain.png
 [typeclasses]: https://www.haskell.org/tutorial/classes.html
 [wikipediahaskell]: https://en.wikipedia.org/wiki/Haskell_(programming_language)
+[callbyname]: https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_name
+[mathematicalfunctions]: addenda#mathematical-functions
+[inlining]: https://en.wikipedia.org/wiki/Inline_expansion
+[referentialtransparency]: https://en.wikipedia.org/wiki/Referential_transparency
+[stacksetup]: https://docs.haskellstack.org/en/stable/README/#how-to-install
+[ghcicommands]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-commands
+[shadowing]: https://en.wikipedia.org/wiki/Variable_shadowing
+[nonstrictversuslazy]: https://stackoverflow.com/questions/7140978/haskell-how-does-non-strict-and-lazy-differ#7141537

--- a/part02.md
+++ b/part02.md
@@ -27,7 +27,7 @@ z :: Num a => a
 11
 ```
 
-Now lets rename our function `addIntegers` and provide a type annotation:
+Now let's rename our function `addIntegers` and provide a type annotation:
 
 ```ghci
 λ> addIntegers :: Integer -> Integer -> Integer; addIntegers x y = x + y

--- a/part02.md
+++ b/part02.md
@@ -6,24 +6,38 @@ title: "Part 2: Functions"
 
 But, wait, isn't Haskell supposed to be a functional programming language? It's already part 2 of the course and we haven't encountered any functions yet.
 
-Since Haskell is a functional programming language, functions are first-class values. You will recall an earlier example with a value named `z` which was the result of applying the `+` operator to `x` and `y`. Let's generalize this to a function that adds its two arguments together:
+Since Haskell is a functional programming language, functions are first-class values. Recall our earlier example with a value named `z` which was the result of applying the `+` operator to `x` and `y`.
+
+
+```ghci
+λ> x = 5
+λ> y = 6
+λ> z = x + y
+λ> z
+11
+```
+
+Let's generalize this to a function that adds its two arguments together:
+
+```ghci
+λ> z x y = x + y
+λ> :t z
+z :: Num a => a
+λ> z 6 7
+11
+```
+
+Now lets rename our function `addIntegers` and provide a type annotation:
 
 ```ghci
 λ> addIntegers :: Integer -> Integer -> Integer; addIntegers x y = x + y
 λ> :t addIntegers
 addIntegers :: Integer -> Integer -> Integer
+λ> addIntegers 6 7
+11
 ```
 
 The `:t` command yields the type signature for `addIntegers`: in this case a function taking two `Integer`s and evaluating to a third `Integer`. The function's "return" type is the rightmost type in the signature. The `->` operator is read as "to" or "maps to".
-
-We can use this function as follows:
-
-```ghci
-λ> addIntegers 5 6
-11
-λ> addIntegers 10 11
-21
-```
 
 Many languages use parentheses, `(` and `)`, to delimit the arguments of a function application or call. Functions are so central to the Haskell Way that the language designers intentionally chose the tersest syntax possible for function definitions and function application. Thus, instead of:
 
@@ -41,6 +55,8 @@ g x y = x ^ 3 + y ^ 3
 h x y = f x y + g x y
 ```
 
+Note that `f` and `g` are in scope for `h`.
+
 To further reduce the use of parentheses, Haskell also assigns the highest precedence of all infix operators to function application.
 
 Moving our `addIntegers` function to a source file and adding its type signature, we get:
@@ -55,7 +71,7 @@ main = print (addIntegers 5 6)
 
 To reiterate, this defines a function `addIntegers` that takes an `Integer`, a second `Integer` and evaluates to an `Integer` (analogous to "returning" an `Integer` in imperative programming languages).
 
-Since `addIntegers` is a value much like `z`, albeit one with arguments, it can be passed as an argument to other functions. In this respect, `addIntegers` is much like `z` or  `5`, `"hello"` or any other value:
+Since `addIntegers` is a value much like `z`, albeit one with arguments, it can be passed as an argument to other functions. In this respect, `addIntegers` is much like `z` or  `5`, `"hello"` or any other value.
 
 ```haskell
 addIntegers :: Integer -> Integer -> Integer
@@ -70,7 +86,7 @@ main = print (functionTakingAFunction addIntegers 5 6)
 
 # Anonymous functions and lambda abstraction
 
-Functions are so important in Haskell that we get to refer to them by name or with no name at all. They also get their own letter of the Greek alphabet: lambda, so-called because of [the lambda calculus][lambdacalculus]. Lambda calculus is a universal model of computation equivalent in power to the Turing machine. It's based on function abstraction and function application and this is the bare minimum you need to know to get started with Haskell.
+Functions are so important in Haskell that we get to refer to them by name or with no name at all. They also get their own letter of the Greek alphabet: lambda, so-called because of [the lambda calculus][lambdacalculus]. Lambda calculus is a universal model of computation, equivalent in power to the Turing machine. It's based on function abstraction and function application and this is the bare minimum you need to know to get started with Haskell.
 
 Consider the named (mathematical) function $\operatorname{square\_sum}$:
 

--- a/resources/buttondown.css
+++ b/resources/buttondown.css
@@ -114,6 +114,9 @@ p {}
 blockquote
     {
     font-style: italic;
+    border-left: .3em solid #eee;
+    padding-left: .6em;
+    margin-left: .68em;
     }
 
 li /* All list items */
@@ -127,6 +130,7 @@ li > p /* Loosely spaced list item */
 
 ul /* Whole unordered list */
     {
+    padding-left: 1.5em;
     }
 
 ul li /* Unordered list item */
@@ -134,12 +138,13 @@ ul li /* Unordered list item */
     }
 
 ol /* Whole ordered list */
-    {
-    }
+   {
+   padding-left: 1.5em;
+   }
 
 ol li /* Ordered list item */
-    {
-    }
+   {
+   }
 
 hr {}
 
@@ -232,7 +237,8 @@ p.caption /* Pandoc figure-style caption within div.figure */
 pre, code
     {
     font-size: 110%;
-    background-color: #fdf7ee;
+    background-color: #f0f0f0;
+    line-height: 1.2em;
     /* BEGIN word wrap */
     /* Need all the following to word wrap instead of scroll box */
     /* This will override the overflow:auto if present */
@@ -244,15 +250,21 @@ pre, code
     /* END word wrap */
     }
 
+code
+    {
+    border-radius: 2px;
+    padding: 0.15em;
+    }
+
 pre /* Code blocks */
     {
     /* Distinguish pre blocks from other text by more than the font with a background tint. */
     padding: 0.5em; /* Since we have a background color */
-    border-radius: 5px; /* Softens it */
+    border-radius: 3px; /* Softens it */
     /* Give it a some definition */
-    border: 1px solid #aaa;
+    border: 1px solid #eee;
     /* Set it off left and right, seems to look a bit nicer when we have a background */
-    margin-left:  0.5em;
+    margin-left:  0.68em;
     margin-right: 0.5em;
     }
 
@@ -263,8 +275,8 @@ pre /* Code blocks */
         /* On screen, use an auto scroll box for long lines, unless word-wrap is enabled */
         white-space: pre;
         overflow: auto;
-        /* Dotted looks better on screen and solid seems to print better. */
-        border: 1px dotted #777;
+        border: 1px solid #eee;
+        margin: 0 0.68em 0 0.68em;
         }
     }
 
@@ -317,16 +329,13 @@ table
 
     border-bottom: 2pt solid #000;
     border-top: 2pt solid #000; /* The caption on top will not have a bottom-border */
-
-    /* Center */
-    margin-left: auto;
-    margin-right: auto;
     }
 
 thead /* Entire table header */
     {
     border-bottom: 1pt solid #000;
     background-color: #eee; /* Does this BG print well? */
+    text-align: left;
     }
 
 tr.header /* Each header row */

--- a/resources/nav.html
+++ b/resources/nav.html
@@ -7,5 +7,6 @@
   <a href="part05">Ugly code</a> |
   <a href="part06">Other</a> |
   <a href="q-and-a">Q&amp;A</a> |
+  <a href="addenda">Addenda</a> |
   <a href="https://github.com/rcook/beginning-practical-haskell/issues">Found a bug?</a>
 </nav>

--- a/resources/tufte.css
+++ b/resources/tufte.css
@@ -1,0 +1,275 @@
+@charset "UTF-8";
+
+/* Import ET Book styles
+   adapted from https://github.com/edwardtufte/et-book/blob/gh-pages/et-book.css */
+
+@font-face { font-family: "et-book";
+             src: url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.eot");
+             src: url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.eot?#iefix") format("embedded-opentype"), url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.woff") format("woff"), url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.ttf") format("truetype"), url("et-book/et-book-roman-line-figures/et-book-roman-line-figures.svg#etbookromanosf") format("svg");
+             font-weight: normal;
+             font-style: normal; }
+
+@font-face { font-family: "et-book";
+             src: url("et-book/et-book-display-italic-old-style-figures/et-book-display-italic-old-style-figures.eot");
+             src: url("et-book/et-book-display-italic-old-style-figures/et-book-display-italic-old-style-figures.eot?#iefix") format("embedded-opentype"), url("et-book/et-book-display-italic-old-style-figures/et-book-display-italic-old-style-figures.woff") format("woff"), url("et-book/et-book-display-italic-old-style-figures/et-book-display-italic-old-style-figures.ttf") format("truetype"), url("et-book/et-book-display-italic-old-style-figures/et-book-display-italic-old-style-figures.svg#etbookromanosf") format("svg");
+             font-weight: normal;
+             font-style: italic; }
+
+@font-face { font-family: "et-book";
+             src: url("et-book/et-book-bold-line-figures/et-book-bold-line-figures.eot");
+             src: url("et-book/et-book-bold-line-figures/et-book-bold-line-figures.eot?#iefix") format("embedded-opentype"), url("et-book/et-book-bold-line-figures/et-book-bold-line-figures.woff") format("woff"), url("et-book/et-book-bold-line-figures/et-book-bold-line-figures.ttf") format("truetype"), url("et-book/et-book-bold-line-figures/et-book-bold-line-figures.svg#etbookromanosf") format("svg");
+             font-weight: bold;
+             font-style: normal; }
+
+@font-face { font-family: "et-book-roman-old-style";
+             src: url("et-book/et-book-roman-old-style-figures/et-book-roman-old-style-figures.eot");
+             src: url("et-book/et-book-roman-old-style-figures/et-book-roman-old-style-figures.eot?#iefix") format("embedded-opentype"), url("et-book/et-book-roman-old-style-figures/et-book-roman-old-style-figures.woff") format("woff"), url("et-book/et-book-roman-old-style-figures/et-book-roman-old-style-figures.ttf") format("truetype"), url("et-book/et-book-roman-old-style-figures/et-book-roman-old-style-figures.svg#etbookromanosf") format("svg");
+             font-weight: normal;
+             font-style: normal; }
+
+/* Tufte CSS styles */
+html { font-size: 15px; }
+
+body { width: 87.5%;
+       margin-left: auto;
+       margin-right: auto;
+       padding-left: 12.5%;
+       font-family: et-book, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
+       background-color: #fffff8;
+       color: #111;
+       max-width: 1400px;
+       counter-reset: sidenote-counter; }
+
+h1 { font-weight: 400;
+     margin-top: 4rem;
+     margin-bottom: 1.5rem;
+     font-size: 3.2rem;
+     line-height: 1; }
+
+h2 { font-style: italic;
+     font-weight: 400;
+     margin-top: 2.1rem;
+     margin-bottom: 1.4rem;
+     font-size: 2.2rem;
+     line-height: 1; }
+
+h3 { font-style: italic;
+     font-weight: 400;
+     font-size: 1.7rem;
+     margin-top: 2rem;
+     margin-bottom: 1.4rem;
+     line-height: 1; }
+
+hr { display: block;
+     height: 1px;
+     width: 55%;
+     border: 0;
+     border-top: 1px solid #ccc;
+     margin: 1em 0;
+     padding: 0; }
+
+p.subtitle { font-style: italic;
+             margin-top: 1rem;
+             margin-bottom: 1rem;
+             font-size: 1.8rem;
+             display: block;
+             line-height: 1; }
+
+.numeral { font-family: et-book-roman-old-style; }
+
+.danger { color: red; }
+
+article { position: relative;
+          padding: 5rem 0rem; }
+
+section { padding-top: 1rem;
+          padding-bottom: 1rem; }
+
+p, ol, ul { font-size: 1.4rem;
+            line-height: 2rem; }
+
+p { margin-top: 1.4rem;
+    margin-bottom: 1.4rem;
+    padding-right: 0;
+    vertical-align: baseline; }
+
+/* Chapter Epigraphs */
+div.epigraph { margin: 5em 0; }
+
+div.epigraph > blockquote { margin-top: 3em;
+                            margin-bottom: 3em; }
+
+div.epigraph > blockquote, div.epigraph > blockquote > p { font-style: italic; }
+
+div.epigraph > blockquote > footer { font-style: normal; }
+
+div.epigraph > blockquote > footer > cite { font-style: italic; }
+/* end chapter epigraphs styles */
+
+blockquote { font-size: 1.4rem; }
+
+blockquote p { width: 55%;
+               margin-right: 40px; }
+
+blockquote footer { width: 55%;
+                    font-size: 1.1rem;
+                    text-align: right; }
+
+section > p, section > footer, section > table { width: 55%; }
+
+/* 50 + 5 == 55, to be the same width as paragraph */
+section > ol, section > ul { width: 50%;
+                             -webkit-padding-start: 5%; }
+
+li:not(:first-child) { margin-top: 0.25rem; }
+
+figure { padding: 0;
+         border: 0;
+         font-size: 100%;
+         font: inherit;
+         vertical-align: baseline;
+         max-width: 55%;
+         -webkit-margin-start: 0;
+         -webkit-margin-end: 0;
+         margin: 0 0 3em 0; }
+
+figcaption { float: right;
+             clear: right;
+             margin-top: 0;
+             margin-bottom: 0;
+             font-size: 1.1rem;
+             line-height: 1.6;
+             vertical-align: baseline;
+             position: relative;
+             max-width: 40%; }
+
+figure.fullwidth figcaption { margin-right: 24%; }
+
+/* Links: replicate underline that clears descenders */
+a:link, a:visited { color: inherit; }
+
+a:link { text-decoration: none;
+         background: -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#333, #333);
+         background: linear-gradient(#fffff8, #fffff8), linear-gradient(#fffff8, #fffff8), linear-gradient(#333, #333);
+         -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+         -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+         background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
+         background-repeat: no-repeat, no-repeat, repeat-x;
+         text-shadow: 0.03em 0 #fffff8, -0.03em 0 #fffff8, 0 0.03em #fffff8, 0 -0.03em #fffff8, 0.06em 0 #fffff8, -0.06em 0 #fffff8, 0.09em 0 #fffff8, -0.09em 0 #fffff8, 0.12em 0 #fffff8, -0.12em 0 #fffff8, 0.15em 0 #fffff8, -0.15em 0 #fffff8;
+         background-position: 0% 93%, 100% 93%, 0% 93%; }
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) { a:link { background-position-y: 87%, 87%, 87%; } }
+
+a:link::selection { text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
+                    background: #b4d5fe; }
+
+a:link::-moz-selection { text-shadow: 0.03em 0 #b4d5fe, -0.03em 0 #b4d5fe, 0 0.03em #b4d5fe, 0 -0.03em #b4d5fe, 0.06em 0 #b4d5fe, -0.06em 0 #b4d5fe, 0.09em 0 #b4d5fe, -0.09em 0 #b4d5fe, 0.12em 0 #b4d5fe, -0.12em 0 #b4d5fe, 0.15em 0 #b4d5fe, -0.15em 0 #b4d5fe;
+                         background: #b4d5fe; }
+
+/* Sidenotes, margin notes, figures, captions */
+img { max-width: 100%; }
+
+.sidenote, .marginnote { float: right;
+                         clear: right;
+                         margin-right: -60%;
+                         width: 50%;
+                         margin-top: 0;
+                         margin-bottom: 0;
+                         font-size: 1.1rem;
+                         line-height: 1.3;
+                         vertical-align: baseline;
+                         position: relative; }
+
+.sidenote-number { counter-increment: sidenote-counter; }
+
+.sidenote-number:after, .sidenote:before { font-family: et-book-roman-old-style;
+                                           position: relative;
+                                           vertical-align: baseline; }
+
+.sidenote-number:after { content: counter(sidenote-counter);
+                         font-size: 1rem;
+                         top: -0.5rem;
+                         left: 0.1rem; }
+
+.sidenote:before { content: counter(sidenote-counter) " ";
+                   top: -0.5rem; }
+
+blockquote .sidenote, blockquote .marginnote { margin-right: -82%;
+                                               min-width: 59%;
+                                               text-align: left; }
+
+div.fullwidth, table.fullwidth { width: 100%; }
+
+div.table-wrapper { overflow-x: auto;
+                    font-family: "Trebuchet MS", "Gill Sans", "Gill Sans MT", sans-serif; }
+
+.sans { font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif;
+        letter-spacing: .03em; }
+
+code { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+       font-size: 1.0rem;
+       line-height: 1.42; }
+
+.sans > code { font-size: 1.2rem; }
+
+h1 > code, h2 > code, h3 > code { font-size: 0.80em; }
+
+.marginnote > code, .sidenote > code { font-size: 1rem; }
+
+pre.code { font-size: 0.9rem;
+           width: 52.5%;
+           margin-left: 2.5%;
+           overflow-x: auto; }
+
+pre.code.fullwidth { width: 90%; }
+
+.fullwidth { max-width: 90%;
+             clear:both; }
+
+span.newthought { font-variant: small-caps;
+                  font-size: 1.2em; }
+
+input.margin-toggle { display: none; }
+
+label.sidenote-number { display: inline; }
+
+label.margin-toggle:not(.sidenote-number) { display: none; }
+
+.iframe-wrapper { position: relative;
+                  padding-bottom: 56.25%; /* 16:9 */
+                  padding-top: 25px;
+                  height: 0; }
+
+.iframe-wrapper iframe { position: absolute;
+                         top: 0;
+                         left: 0;
+                         width: 100%;
+                         height: 100%; }
+
+@media (max-width: 760px) { body { width: 84%;
+                                   padding-left: 8%;
+                                   padding-right: 8%; }
+                            section > p, section > footer, section > table { width: 100%; }
+                            pre.code { width: 97%; }
+                            section > ol { width: 90%; }
+                            section > ul { width: 90%; }
+                            figure { max-width: 90%; }
+                            figcaption, figure.fullwidth figcaption { margin-right: 0%;
+                                                                      max-width: none; }
+                            blockquote { margin-left: 1.5em;
+                                         margin-right: 0em; }
+                            blockquote p, blockquote footer { width: 100%; }
+                            label.margin-toggle:not(.sidenote-number) { display: inline; }
+                            .sidenote, .marginnote { display: none; }
+                            .margin-toggle:checked + .sidenote,
+                            .margin-toggle:checked + .marginnote { display: block;
+                                                                   float: left;
+                                                                   left: 1rem;
+                                                                   clear: both;
+                                                                   width: 95%;
+                                                                   margin: 1rem 2.5%;
+                                                                   vertical-align: baseline;
+                                                                   position: relative; }
+                            label { cursor: pointer; }
+                            div.table-wrapper, table { width: 85%; }
+                            img { width: 100%; } }


### PR DESCRIPTION
In general these changes expand the introduction by turning most bulleted lists into paragraphs.  Some explanations have been amended, though as a rule in minor ways.  In a few places I've made intermediate steps explicit with additional code blocks.

The style changes are in concert with the move from bullets to paragraphs, with the goal of making reading experience flow (fewer levels of indentation; toned-down style on code blocks).

The TOC has been removed since one is auto-generated, and it has been replaced with a few sentences on the organization of the introduction. 

Several terms have had links to references added.

Some notes have been extracted into an Addenda page, such as pronunciation notes.  

However! The style changes and addenda page I hope are temporary, because I think it would be useful to try to use Tufte's css.  The main benefit is the use of margin notes.  I think this will allow us to include more information without interrupting the logic sequence of the presentation of material.  I've included the tufte.css in this PR, and you can preview an approximation of it by changing the yaml css variable.  However, there's  a little more work involved in getting the margin notes to function.  See: https://github.com/walkermalling/beginning-practical-haskell/issues/2
